### PR TITLE
#16: set nginx.conf & docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,36 @@
 services:
-  back:
+  spring:
     image: capstone1234z/capstone-secret:tagname
-    ports:
-      - "80:8080"
+    expose:
+      - 8080
     volumes:
       - ./application.yml:/config/application.yml
     command: ["java", "-jar", "app.jar", "--spring.config.location=file:/config/application.yml"]
+
+
+  nginx:
+    image: nginx:stable
+    depends_on:
+      - spring
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+  #      - ./nginx/conf.d:/etc/nginx/conf.d 모듈화 까지는 안할거니까 주석화
+
+  certbot:
+    depends_on:
+      - nginx
+    image: certbot/certbot
+    volumes:
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+
+    # 실제 서비스용 인증 발급
+    entrypoint: "/bin/sh -c 'trap exit TERM; if [ ! -e /etc/letsencrypt/live/엄준식.shop/fullchain.pem ]; then certbot certonly --webroot --webroot-path=/var/www/certbot -d 엄준식.shop --email jo1814@naver.com --agree-tos --no-eff-email; fi; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
 
   # EC2 인스턴스 내부에서 Spring-Boot 컨테이너, MySql 컨테이너 + github action Runner 까지 돌리니까
   # 서버가 버티질 못해서 그냥 DB는 AWS RDS로 뺐음.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,34 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+        server_name 엄준식.shop;
+
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+#처음 발급 받을때는 밑에 주석 처리하고 할것.
+    server {
+        listen 443 ssl;
+        server_name 엄준식.shop;
+
+        ssl_certificate /etc/letsencrypt/live/엄준식.shop/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/엄준식.shop/privkey.pem;
+        location / {
+            proxy_pass http://spring:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/src/main/java/idusw/sbb/maple/config/SwaggerConfig.java
+++ b/src/main/java/idusw/sbb/maple/config/SwaggerConfig.java
@@ -6,17 +6,28 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+  @Value("${swagger.env}")
+  private String env;
+
+  @Value("${swagger.local-url}")
+  private String localUrl;
+
+  @Value("${swagger.develop-url}")
+  private String developUrl;
+
   @Bean
   public OpenAPI openAPI() {
     Server server = new Server();
 
-    server.setUrl("https://modern-world.shop");
+    String serverUrl = env.equals("local") ? localUrl: developUrl;
 
+    server.setUrl(serverUrl);
 
     return new OpenAPI()
         .components(new Components())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,10 @@ springdoc:
   swagger-ui:
     path:  # API 명세서 접근 경로에 대한 별칭 swagger-ui/index.html로 리다이렉션 됨.
       /api
+
+# 스웨거 요청 url 설정 환경변수 env에 따라서 어느곳으로 요청을 보낼건지 달라짐.
+# SwaggerConfig Class 참조
+swagger:
+  env: local # 또는 develop
+  local-url: http://localhost:8080/
+  develop-url: https://modern-world.shop/


### PR DESCRIPTION
Https 구현을 위해 서버에는 NginX, Certbot이 띄워져있는 상태입니다.
자세한 정보는 아래와 같습니다.
![image](https://github.com/user-attachments/assets/66dbcd47-00d2-4c17-a34d-833a29a36853)



Certbot이 Let's Encrypt 재단으로부터 SSL 인증서를 가져옵니다.
NginX가 가져온 인증서를 바탕으로 HTTPS 기능을 구현합니다. 
현재 80번 포트로 들어오는 요청은 모두 443으로 가게끔 되어있습니다.
443으로 들어온 요청은 컨테이너 네트워크 내부적으로 다시 spirng boot의 8080번 포트로 연결되게끔 해놓았습니다. 